### PR TITLE
Add types

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,28 +20,35 @@
   "contributors": [
     "Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)"
   ],
+  "types": "types/index.d.ts",
   "files": [
+    "types/index.d.ts",
     "index.js"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "@types/unist": "^2.0.2"
+  },
   "devDependencies": {
     "browserify": "^16.0.0",
+    "dtslint": "^0.4.2",
     "nyc": "^13.0.0",
     "prettier": "^1.12.1",
     "remark-cli": "^6.0.0",
     "remark-preset-wooorm": "^4.0.0",
     "tape": "^4.5.1",
     "tinyify": "^2.4.3",
+    "typescript": "^3.2.2",
     "xo": "^0.23.0"
   },
   "scripts": {
-    "format": "remark . -qfo && prettier --write '**/*.js' && xo --fix",
+    "format": "remark . -qfo && prettier --write '**/*.{js,ts}' && xo --fix",
     "build-bundle": "browserify . -s unistUtilStringifyPosition > unist-util-stringify-position.js",
     "build-mangle": "browserify . -s unistUtilStringifyPosition -p tinyify > unist-util-stringify-position.min.js",
     "build": "npm run build-bundle && npm run build-mangle",
     "test-api": "node test",
     "test-coverage": "nyc --reporter lcov tape test.js",
-    "test": "npm run format && npm run build && npm run test-coverage"
+    "test-types": "dtslint types",
+    "test": "npm run format && npm run build && npm run test-coverage && npm run test-types"
   },
   "nyc": {
     "check-coverage": true,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,9 @@
+// TypeScript Version: 3.0
+
+import * as Unist from 'unist'
+
+declare function unistUtilStringifyPosition(
+  value: Unist.Node | Unist.Position | Unist.Point
+): string
+
+export = unistUtilStringifyPosition

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": ".",
+    "paths": {
+      "unist-util-stringify-position": ["index.d.ts"]
+    }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,14 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "callable-types": false,
+    "max-line-length": false,
+    "no-redundant-jsdoc": false,
+    "no-void-expression": false,
+    "only-arrow-functions": false,
+    "semicolon": false,
+    "unified-signatures": false,
+    "whitespace": false,
+    "interface-over-type-literal": false
+  }
+}

--- a/types/unist-util-stringify-position-tests.ts
+++ b/types/unist-util-stringify-position-tests.ts
@@ -1,0 +1,20 @@
+import stringify = require('unist-util-stringify-position')
+
+// Point
+const stringValue: string = stringify({line: 2, column: 3}) // => '2:3'
+
+// Position
+const stringValue2: string = stringify({
+  start: {line: 2, column: 1},
+  end: {line: 3, column: 1}
+}) // => '2:1-3:1'
+
+// Node
+const stringValue3: string = stringify({
+  type: 'text',
+  value: '!',
+  position: {
+    start: {line: 5, column: 11},
+    end: {line: 5, column: 12}
+  }
+}) // => '5:11-5:12'


### PR DESCRIPTION
I don't think the return type should be union type of `string` and `null` because typescript assure the argument should be `Node`, `Position` or `Point`.

Otherwise, we need to check the return value every time if it is `string` or not. That would be horrible.

Or maybe it is nice time to change the behavior of the function so we can sure it always returns a `string`.  (Like returning empty string or throwing an error when it gets an invalid input)